### PR TITLE
Fix typo in an example from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ TRender('''
 	I'm not perfect..
 #end
 
-''').render({'almost_perfect': true}) 
+''').render({'almost_perfect': True})
 
 # Output => "I'm almost perfect"
 ```


### PR DESCRIPTION
The change fixes a typo in python's True value name, which appers to
be lower-case in an example from README.md. This avoids a runtime
issue while trying to execute the example code snippet:

  NameError: name 'true' is not defined

Signed-off-by: Vladimir Zapolskiy vz@mleia.com
